### PR TITLE
Get news through a proxy w/o authentication

### DIFF
--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -457,12 +457,17 @@ class General extends AsyncBase
         ];
 
         if ($this->getOption('general/httpProxy')) {
-            $options['proxy'] = sprintf(
-                '%s:%s@%s',
-                $this->getOption('general/httpProxy/user'),
-                $this->getOption('general/httpProxy/password'),
-                $this->getOption('general/httpProxy/host')
-            );
+            if ($this->getOption('general/httpProxy/user') != '') {
+                $options['proxy'] = sprintf(
+                    '%s:%s@%s',
+                    $this->getOption('general/httpProxy/user'),
+                    $this->getOption('general/httpProxy/password'),
+                    $this->getOption('general/httpProxy/host')
+                );
+            }
+            else {
+                $options['proxy'] = $this->getOption('general/httpProxy/host');
+            }
         }
 
         return $options;


### PR DESCRIPTION
This patch allows bolt to look for news using a proxy without user/password fields, if general/httpProxy/user is empty

Details
-------

This PR may be tested using a simple squid proxy
   
Choosing a target branch
------------------------

Change made on branch 3.5
